### PR TITLE
Add dynamic Substack RSS feed fetch

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -98,17 +98,17 @@ nav {
   margin-bottom: 1rem;
   font-weight: 600;
 }
-#posts-container article {
+#substack-posts article {
   margin-bottom: 1.5rem;
 }
-#posts-container h3 {
+#substack-posts h3 {
   margin-bottom: 0.25rem;
   font-size: 1.1rem;
 }
-#posts-container small {
+#substack-posts small {
   color: gray;
 }
-#posts-container p {
+#substack-posts p {
   margin-top: 0.5rem;
 }
 #about h1 {

--- a/index.html
+++ b/index.html
@@ -44,26 +44,9 @@
       <h1>Zawaad Khan</h1>
       <p>A Naturale Liberal by conviction</p>
     </section>
-    <section id="substack-posts">
-      <h2>Featured Essays</h2>
-      <div class="substack-post-embed"><p lang="en">The Collapse of Intellectual Pluralism by Zawaad Khan</p><p>Universities and colleges have stopped challenging conventional wisdom by surrendering to ideological comfort zones, betraying their founding purpose</p><a data-post-link href="https://zawaadkhan.substack.com/p/the-collapse-of-intellectual-pluralism">Read on Substack</a></div><script async src="https://substack.com/embedjs/embed.js" charset="utf-8"></script>
-      <div class="substack-post-embed"><p lang="en">Awakening Minds by Zawaad Khan</p><p>Bangladesh’s Education and the Promise of the Voucher System</p><a data-post-link href="https://zawaadkhan.substack.com/p/awakening-minds">Read on Substack</a></div><script async src="https://substack.com/embedjs/embed.js" charset="utf-8"></script>
-      <div class="substack-post-embed"><p lang="en">Newport Promise by Zawaad Khan</p><p></p><a data-post-link href="https://zawaadkhan.substack.com/p/newport-promise">Read on Substack</a></div><script async src="https://substack.com/embedjs/embed.js" charset="utf-8"></script>
-      <div id="posts-container"></div>
-      <script>
-        window.SubstackFeedWidget = {
-          substackUrl: "zawaadkhan.substack.com",
-          posts: 5,
-          layout: "center",
-          colors: {
-            primary: "#7b1113",
-            secondary: "#ffffff",
-            background: "#ffffff"
-          }
-        };
-      </script>
-      <script src="https://substackapi.com/widget.js" async></script>
-    </section>
+      <div id="substack-posts">
+        <h2>Featured Essays</h2>
+      </div>
   </main>
 
   <!-- Footer -->

--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,47 @@
 // ========================
 // DOM loaded
 document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('substack-posts');
+  if (!container) return;
 
-  // Placeholder for future JS functionality
+  const feedUrl = 'https://zawaadkhan.substack.com/feed';
+
+  fetch(feedUrl)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.text();
+    })
+    .then((str) => new window.DOMParser().parseFromString(str, 'text/xml'))
+    .then((data) => {
+      const items = Array.from(data.querySelectorAll('item')).slice(0, 3);
+      if (!items.length) {
+        throw new Error('No items in feed');
+      }
+
+      let html = '';
+      items.forEach((item) => {
+        const title = item.querySelector('title')?.textContent || 'Untitled';
+        const link = item.querySelector('link')?.textContent || '#';
+        const description = item.querySelector('description')?.textContent || '';
+
+        const preview = description
+          .replace(/(<([^>]+)>)/gi, '')
+          .trim()
+          .slice(0, 140);
+
+        html += `
+          <article class="substack-post">
+            <h3><a href="${link}" target="_blank" rel="noopener">${title}</a></h3>
+            <p>${preview}${description.length > 140 ? '…' : ''}</p>
+          </article>`;
+      });
+
+      container.insertAdjacentHTML('beforeend', html);
+    })
+    .catch(() => {
+      container.innerHTML +=
+        '<p>Unable to load posts. Visit <a href="https://zawaadkhan.substack.com/">my Substack</a> for more.</p>';
+    });
 });


### PR DESCRIPTION
## Summary
- replace Substack embed with a custom container
- fetch last 3 posts from the Substack RSS feed and display them
- style posts within the `#substack-posts` section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684171bb90048332b1e459ff32a0947a